### PR TITLE
게시판 정렬 기능

### DIFF
--- a/board/src/main/java/com/example/board/domain/UserAccount.java
+++ b/board/src/main/java/com/example/board/domain/UserAccount.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/board/src/main/resources/data.sql
+++ b/board/src/main/resources/data.sql
@@ -4,22 +4,26 @@ insert into user_account (user_id, user_password, nickname, email, memo, created
                           modified_by)
 values ('ykmxxi', 'asdf1234', 'ykmxxi', 'ykmxxi@mail.com', 'I am ykmxxi.', now(), 'ykmxxi', now(), 'ykmxxi')
 ;
+insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,
+                          modified_by)
+values ('ykmxxi2', 'asdf1234', 'ykmxxi2', 'ykmxxi2@mail.com', 'I am ykmxxi2.', now(), 'ykmxxi2', now(), 'ykmxxi2')
+;
 
 -- 123 게시글
 insert into article (user_account_id, title, content, hashtag, created_by, modified_by, created_at, modified_at)
-values (1, 'Quisque ut erat.', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.
+values (2, 'Quisque ut erat.', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.
 
 Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.
 
 Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.',
         '#pink', 'Kamilah', 'Murial', '2021-05-30 23:53:46', '2021-03-10 08:48:50'),
-       (1, 'Morbi ut odio.', 'Phasellus in felis. Donec semper sapien a libero. Nam dui.
+       (2, 'Morbi ut odio.', 'Phasellus in felis. Donec semper sapien a libero. Nam dui.
 
 Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius.
 
 Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.', '#purple', 'Arv', 'Keelby',
         '2021-05-06 11:51:24', '2021-05-23 08:34:54'),
-       (1,
+       (2,
         'Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio.',
         'Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.', '#purple', 'Adams', 'Thalia',
         '2021-08-13 08:32:22', '2021-04-02 02:58:19'),

--- a/board/src/main/resources/static/css/articles/table-header.css
+++ b/board/src/main/resources/static/css/articles/table-header.css
@@ -1,0 +1,5 @@
+/* 게시글 테이블 제목 */
+#article-table > thead a {
+    text-decoration: none;
+    color: black;
+}

--- a/board/src/main/resources/templates/articles/index.html
+++ b/board/src/main/resources/templates/articles/index.html
@@ -60,10 +60,10 @@
   <table class="table" id="article-table">
     <thead>
     <tr>
-      <th class="title col-6">제목</th>
-      <th class="hashtag col-2">해시태그</th>
-      <th class="user-id col">작성자</th>
-      <th class="created-at col">작성일</th>
+      <th class="title col-6"><a>제목</a></th>
+      <th class="hashtag col-2"><a>해시태그</a></th>
+      <th class="user-id col"><a>작성자</a></th>
+      <th class="created-at col"><a>작성일</a></th>
     </tr>
     </thead>
     <tbody>

--- a/board/src/main/resources/templates/articles/index.th.xml
+++ b/board/src/main/resources/templates/articles/index.th.xml
@@ -3,35 +3,56 @@
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
 
-    <attr sel="#article-table">
-        <attr sel="tbody" th:remove="all-but-first">
-            <attr sel="tr[0]" th:each="article : ${articles}">
-                <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}"/>
-                <attr sel="td.hashtag" th:text="${article.hashtag}"/>
-                <attr sel="td.user-id" th:text="${article.nickname}"/>
-                <attr sel="td.created-by/time" th:datetime="${article.createdAt}"
-                      th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}"/>
+    <attr sel="main" th:object="${articles}">
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles(
+            page=${articles.number},
+            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : '')
+        )}"/>
+                <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
+            page=${articles.number},
+            sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : '')
+        )}"/>
+                <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles(
+            page=${articles.number},
+            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : '')
+        )}"/>
+                <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles(
+            page=${articles.number},
+            sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : '')
+        )}"/>
+            </attr>
+
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}"/>
+                    <attr sel="td.hashtag" th:text="${article.hashtag}"/>
+                    <attr sel="td.user-id" th:text="${article.nickname}"/>
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}"
+                          th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}"/>
+                </attr>
             </attr>
         </attr>
-    </attr>
 
-    <attr sel="#pagination">
-        <attr sel="li[0]/a"
-              th:text="'previous'"
-              th:href="@{/articles(page=${articles.number - 1})}"
-              th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
-        />
-        <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
-            <attr sel="a"
-                  th:text="${pageNumber + 1}"
-                  th:href="@{/articles(page=${pageNumber})}"
-                  th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+        <attr sel="#pagination">
+            <attr sel="li[0]/a"
+                  th:text="'previous'"
+                  th:href="@{/articles(page=${articles.number - 1})}"
+                  th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+            />
+            <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                <attr sel="a"
+                      th:text="${pageNumber + 1}"
+                      th:href="@{/articles(page=${pageNumber})}"
+                      th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                />
+            </attr>
+            <attr sel="li[2]/a"
+                  th:text="'next'"
+                  th:href="@{/articles(page=${articles.number + 1})}"
+                  th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
             />
         </attr>
-        <attr sel="li[2]/a"
-              th:text="'next'"
-              th:href="@{/articles(page=${articles.number + 1})}"
-              th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
-        />
     </attr>
 </thlogic>

--- a/board/src/test/java/com/example/board/repository/JpaRepositoryTest.java
+++ b/board/src/test/java/com/example/board/repository/JpaRepositoryTest.java
@@ -51,7 +51,7 @@ class JpaRepositoryTest {
         // given
         long previous = articleRepository.count();
         UserAccount userAccount = userAccountRepository.save(
-                UserAccount.of("ykmxxi", "password", "email@email.com", "ykmxxi", "hi")
+                UserAccount.of("ykmxxi1", "password", "email@email.com", "ykmxxi", "hi")
         );
 
         // when


### PR DESCRIPTION
정렬 기능: 게시판 페이지에서 각 컬럼(제목, 해시태그, 작성자, 작성일)의 제목을 누르면 해당 값으로 오른차순, 내림차순 정렬이 되게끔 동작

- [x] 정렬 기능 구현
- [x] 뷰에 적용
- [x] 테스트

This closes #26 